### PR TITLE
feat: Display skeletons on initial load to prevent content shift

### DIFF
--- a/application/frontend/src/components/PlaybackControls.tsx
+++ b/application/frontend/src/components/PlaybackControls.tsx
@@ -10,6 +10,7 @@ interface PlaybackControlsProps {
   onRestart: () => void;
   onStop: () => void;
   onJumpProbabilityChange: (value: number) => void;
+  disabled?: boolean;
 }
 
 const IconPlay = () => (
@@ -44,6 +45,7 @@ const PlaybackControls: React.FC<PlaybackControlsProps> = ({
   onRestart,
   onStop,
   onJumpProbabilityChange,
+  disabled = false,
 }) => {
   return (
     <div
@@ -55,8 +57,8 @@ const PlaybackControls: React.FC<PlaybackControlsProps> = ({
         <button
           type="button"
           onClick={onPlayPause}
-          disabled={isPlaybackPending}
-          className={`transport-btn w-14 h-14 sm:w-16 sm:h-16 flex items-center justify-center text-navy-900 ${isPlaying ? 'accent-glow' : ''} ${isPlaybackPending ? 'opacity-50 cursor-not-allowed' : ''}`}
+          disabled={disabled || isPlaybackPending}
+          className={`transport-btn w-14 h-14 sm:w-16 sm:h-16 flex items-center justify-center text-navy-900 ${isPlaying ? 'accent-glow' : ''} ${(disabled || isPlaybackPending) ? 'opacity-50 cursor-not-allowed' : ''}`}
           aria-label={isPlaying ? 'Pause' : isPlaybackPending ? 'Loading...' : 'Play'}
           title={isPlaying ? 'Pause' : isPlaybackPending ? 'Loading...' : 'Play'}
         >
@@ -84,7 +86,8 @@ const PlaybackControls: React.FC<PlaybackControlsProps> = ({
         <button
           type="button"
           onClick={onRestart}
-          className="transport-btn w-12 h-12 sm:w-14 sm:h-14 flex items-center justify-center text-navy-900"
+          disabled={disabled}
+          className={`transport-btn w-12 h-12 sm:w-14 sm:h-14 flex items-center justify-center text-navy-900 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           aria-label="Restart"
           title="Restart"
         >
@@ -103,7 +106,8 @@ const PlaybackControls: React.FC<PlaybackControlsProps> = ({
           step="0.01"
           value={jumpProbability}
           onChange={(e) => onJumpProbabilityChange(parseFloat(e.target.value))}
-          className="w-36 sm:w-48 accent-gold-500"
+          disabled={disabled}
+          className={`w-36 sm:w-48 accent-gold-500 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
           aria-valuemin={0}
           aria-valuemax={1}
           aria-valuenow={jumpProbability}

--- a/application/frontend/src/components/SongMetadataSkeleton.tsx
+++ b/application/frontend/src/components/SongMetadataSkeleton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+
+const MetaRowSkeleton: React.FC = () => (
+  <div className="flex items-center justify-between py-2 border-b border-white/10 last:border-b-0">
+    <div className="h-4 bg-white/10 rounded animate-pulse w-20"></div>
+    <div className="h-4 bg-white/20 rounded animate-pulse w-16"></div>
+  </div>
+);
+
+const SongMetadataSkeleton: React.FC = () => {
+  return (
+    <section className="cdpanel-inner p-4 sm:p-6">
+      <header className="mb-4">
+        <div className="h-5 bg-white/10 rounded animate-pulse w-24 mb-1"></div>
+        <div className="h-3 bg-white/5 rounded animate-pulse w-48"></div>
+      </header>
+      <div className="space-y-1">
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+        <MetaRowSkeleton />
+      </div>
+    </section>
+  );
+};
+
+export default SongMetadataSkeleton;

--- a/application/frontend/src/components/Visualization.tsx
+++ b/application/frontend/src/components/Visualization.tsx
@@ -63,7 +63,7 @@ const Visualization: React.FC<VisualizationProps> = ({ audioFile, beats, current
         waveColor: '#FFD95A',      // gold-400
         progressColor: '#F5C518',  // gold-500
         cursorColor: '#FFFFFF',
-        height: 88,
+        height: 100,
         barWidth: 2,
         barGap: 1,
         barRadius: 2,

--- a/application/frontend/src/components/VisualizationSkeleton.tsx
+++ b/application/frontend/src/components/VisualizationSkeleton.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+
+const VisualizationSkeleton: React.FC = () => {
+  return (
+    <div className="p-4 sm:p-6 device-screen">
+      {/* Waveform skeleton */}
+      <div className="relative">
+        <div className="h-[88px] bg-white/10 rounded animate-pulse"></div>
+      </div>
+
+      {/* Beats visualization skeleton */}
+      <div className="relative mt-4 w-full h-8 sm:h-10 bg-gray-100 rounded animate-pulse">
+        <div className="absolute inset-0 bg-white/20 rounded animate-pulse"></div>
+      </div>
+    </div>
+  );
+};
+
+export default VisualizationSkeleton;


### PR DESCRIPTION
Introduced skeleton loaders for the song metadata and waveform visualization that are displayed during the initial page load and when a new song is being loaded from the library.

This prevents the layout from shifting when the song data is fetched and the components are rendered.

Key changes:
- Created `SongMetadataSkeleton` and `VisualizationSkeleton` components.
- Added an `isLoading` state to `HomePage` to track the initial loading state.
- Updated the rendering logic to show the skeleton components when `isLoading` is true or when a library song is loading.
- Disabled playback controls when no song is loaded to prevent user interaction errors.